### PR TITLE
Fix resource mapping and optimize resource cleanup

### DIFF
--- a/worker/daemon_data_instance.go
+++ b/worker/daemon_data_instance.go
@@ -22,20 +22,25 @@ type (
 )
 
 func (i *instanceData) InstanceResources() []*DBInstanceResource {
-	l := make([]*DBInstanceResource, len(i.resources))
-	id := 0
+	var l []*DBInstanceResource
 	for rID, aResource := range i.resources {
-		var vmName string
+		l = append(l, aToInstanceResource(aResource.(map[string]any), i.svcID, i.nodeID, "", rID,
+			i.resourceMonitored[rID]))
+
 		if i.encap != nil {
 			if encapRid, ok := i.encap[rID].(map[string]any); ok {
+				var vmName string
 				if s, ok := encapRid["hostname"].(string); ok {
 					vmName = s
 				}
+				if encapResources, ok := encapRid["resources"].(map[string]any); ok {
+					for encapRID, encapAResource := range encapResources {
+						l = append(l, aToInstanceResource(encapAResource.(map[string]any), i.svcID, i.nodeID, vmName, encapRID,
+							i.resourceMonitored[encapRID]))
+					}
+				}
 			}
 		}
-		l[id] = aToInstanceResource(aResource.(map[string]any), i.svcID, i.nodeID, vmName, rID,
-			i.resourceMonitored[rID])
-		id++
 	}
 	return l
 }

--- a/worker/job_feed_daemon_status.go
+++ b/worker/job_feed_daemon_status.go
@@ -493,7 +493,6 @@ func (d *jobFeedDaemonStatus) dbUpdateInstances() error {
 				}
 			}
 			instanceMonitorStates[iStatus.monSmonStatus] = true
-			resourceObsoleteAt := time.Now()
 			if iStatus.encap == nil {
 				subNodeID, _, _, err := d.oDb.translateEncapNodename(d.ctx, objID, nodeID)
 				if err != nil {
@@ -519,7 +518,7 @@ func (d *jobFeedDaemonStatus) dbUpdateInstances() error {
 						return fmt.Errorf("dbUpdateInstances update resource %s@%s (%s@%s): %w", objectName, nodename, objID, nodeID, err)
 					}
 					slog.Debug(fmt.Sprintf("dbUpdateInstances deleting obsolete resources %s@%s", objectName, nodename))
-					if err := d.oDb.instanceResourcesDeleteObsolete(d.ctx, objID, nodeID, resourceObsoleteAt); err != nil {
+					if err := d.oDb.instanceResourcesDeleteObsolete(d.ctx, objID, nodeID, d.now); err != nil {
 						return fmt.Errorf("dbUpdateInstances delete obsolete resources %s@%s: %w", objID, nodeID, err)
 					}
 				}
@@ -556,7 +555,7 @@ func (d *jobFeedDaemonStatus) dbUpdateInstances() error {
 						}
 					}
 					slog.Debug(fmt.Sprintf("dbUpdateInstances deleting obsolete container resources %s@%s", objectName, nodename))
-					if err := d.oDb.instanceResourcesDeleteObsolete(d.ctx, objID, nodeID, resourceObsoleteAt); err != nil {
+					if err := d.oDb.instanceResourcesDeleteObsolete(d.ctx, objID, nodeID, d.now); err != nil {
 						return fmt.Errorf("dbUpdateInstances delete obsolete container resources %s@%s: %w", objID, nodeID, err)
 					}
 				}


### PR DESCRIPTION
### Summary

- Fixed an issue in `InstanceResources` to properly handle nested encapsulated resources, ensuring accurate mapping.
- Updated resource cleanup process in `job_feed_daemon_status` to use `db.Now` for removing obsolete resources effectively.
